### PR TITLE
Update for 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,6 @@
     "MicroKanren",
     "MicroKanren.Operators"
   ],
-  "dependencies": { "elm-lang/core": "3.0.0 <= v < 4.0.0" },
-  "elm-version": "0.16.0 <= v < 0.17.0"
+  "dependencies": { "elm-lang/core": "4.0.0 <= v < 5.0.0" },
+  "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/MicroKanren.elm
+++ b/src/MicroKanren.elm
@@ -1,4 +1,4 @@
-module MicroKanren
+module MicroKanren exposing
   ( Var, Term(LVar, LVal, Pair)
   , Substitution, State
   , Stream(Empty, Immature, Mature)
@@ -7,7 +7,7 @@ module MicroKanren
   , mplus, bind
   , walk, extend, unify
   , callFresh, identical, conjoin, disjoin
-  ) where
+  )
 
 {-| μKanren provides a minimal, independent core for relational programming in Elm,
 as described by Hemann and Friedmann in [µKanren: A Minimal Functional Core

--- a/src/MicroKanren/Operators.elm
+++ b/src/MicroKanren/Operators.elm
@@ -1,4 +1,4 @@
-module MicroKanren.Operators(..) where
+module MicroKanren.Operators exposing (..)
 
 {-| Infix operators for μKanren
 


### PR DESCRIPTION
Also I had to rename the files since the filesystem on linux is case sensitive, whereas on OSX/Windows the filesystem is case insensitive. The compiler couldn't find `MicroKanren.elm` since it was `microKanren.elm`
